### PR TITLE
chore: Mention REUSE tool in README, align copyright statements

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,9 +2,29 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: gigya-dotnet-sdk
 Upstream-Contact: Kobi Cohen <kobi.cohen@sap.com>
 Source: https://github.com/SAP/gigya-dotnet-sdk
-
+Disclaimer: The code in this project may include calls to APIs (“API Calls”) of
+ SAP or third-party products or services developed outside of this project
+ (“External Products”).
+ “APIs” means application programming interfaces, as well as their respective
+ specifications and implementing code that allows software to communicate with
+ other software.
+ API Calls to External Products are not licensed under the open source license
+ that governs this project. The use of such API Calls and related External
+ Products are subject to applicable additional agreements with the relevant
+ provider of the External Products. In no event shall the open source license
+ that governs this project grant any rights in or to any External Products,or
+ alter, expand or supersede any terms of the applicable additional agreements.
+ If you have a valid license agreement with SAP for the use of a particular SAP
+ External Product, then you may make use of any API Calls included in this
+ project’s code for that SAP External Product, subject to the terms of such
+ license agreement. If you do not have a valid license agreement for the use of
+ a particular SAP External Product, then you may only make use of any API Calls
+ in this project for that SAP External Product for your internal, non-productive
+ and non-commercial test and evaluation of such API Calls. Nothing herein grants
+ you any rights to use or access any SAP External Product, or provide any third
+ parties the right to use of access any SAP External Product, through API Calls.
 
 Files: *
-Copyright: 2020 SAP SE or an SAP affiliate company
+Copyright: 2020-2021 SAP SE or an SAP affiliate company and gigya-dotnet-sdk contributors
 License: Apache-2.0
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020-2021 SAP SE or an SAP affiliate company and gigya-dotnet-sdk contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Gigya SDK for .NET
 Learn more: http://developers.gigya.com/display/GD/.NET
 
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/gigya-dotnet-sdk)](https://api.reuse.software/info/github.com/SAP/gigya-dotnet-sdk)
+
 ## Description
 The .NET library provides C# interface for the Gigya API.
 The library makes it simple to integrate Gigya's service in your .NET application.
@@ -36,3 +38,6 @@ Via pull request to this repository.
 
 ## To-Do (upcoming changes)
 None
+
+## Licensing
+Please see our [LICENSE](LICENSE.txt) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/gigya-dotnet-sdk).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR adds the REUSE Tool links to the README

**Notes:** 
- Please register the repository with the REUSE Tool to complete the integration (see #11 and #12)
- This PR assumes that no third-party source code was copied in this repository. If this assumption is not correct, please change the .reuse/dep5 file accordingly. Edits by maintainers are enabled in this PR.

Fixes #10